### PR TITLE
SeedData for CarConfigClass

### DIFF
--- a/Data/SeedData.cs
+++ b/Data/SeedData.cs
@@ -6,14 +6,15 @@ namespace CarManufactoring.Data
     {
         internal static void Populate(CarManufactoringContext db)
         {
-            PopulateSemiFinisheds(db);
-            PopulateSection(db);
-            PopulateMachineState(db);
-            PopulateMachines(db);
-            PopulateBrands(db);
-            PopulateInspectionTesting(db);
-            PopulateGender(db);
-            PopulateCars(db);
+           PopulateSemiFinisheds(db);
+           PopulateSection(db);
+           PopulateMachineState(db);
+            // PopulateMachines(db);
+           PopulateBrands(db);
+           PopulateInspectionTesting(db);
+           PopulateGender(db);
+           PopulateCars(db);
+           PopulateCarConfigs(db);
         }
 
         private static void PopulateSemiFinisheds(CarManufactoringContext db)
@@ -142,6 +143,22 @@ namespace CarManufactoring.Data
                 );
 
             db.SaveChanges() ;
+        }
+
+        private static void PopulateCarConfigs(CarManufactoringContext db)
+        {
+            if(db.CarConfig.Any()) return;
+
+            db.CarConfig.AddRange(
+                new CarConfig { AddedPrice = 5000, ConfigName = "Performance Line", CarId = 1, NumExtras = 5 },
+                new CarConfig {  AddedPrice = 7000, ConfigName = "M Line", CarId = 2, NumExtras = 7 },
+                new CarConfig {  AddedPrice = 10000, ConfigName = "Brabus ", CarId = 3, NumExtras = 8 },
+                new CarConfig { AddedPrice = 7000, ConfigName = "S Line", CarId = 4, NumExtras = 6 },
+                new CarConfig { AddedPrice = 5000, ConfigName = "R Line", CarId = 5, NumExtras = 4 },
+                new CarConfig { AddedPrice = 5000, ConfigName = "ST Line", CarId = 6, NumExtras = 5 }
+                );
+
+            db.SaveChanges();
         }
 
         


### PR DESCRIPTION
PopulateMAchines started to give errors because it doesn't allow description nulls yet populate function doesn't add description attribute to any new machine 
![Screenshot 2022-12-09 233945](https://user-images.githubusercontent.com/82943787/206812544-72832453-1de6-4635-8562-7a966a6af49a.png)

