### PR TITLE
Craida Migration que faltava na tabela Materials

### DIFF
--- a/Data/SeedData.cs
+++ b/Data/SeedData.cs
@@ -7,11 +7,11 @@ namespace CarManufactoring.Data
         internal static void Populate(CarManufactoringContext db)
         {
 
+            PopulateGender(db);
             PopulateCollaborators(db);
             PopulateCarParts(db);
-            PopulateGender(db);
             PopulateSemiFinisheds(db);
-            PopulateMaterials(db);
+            PopulateMaterials(db); 
             PopulateSection(db);
             PopulateSectionManager(db);
             PopulateMachineState(db);

--- a/Migrations/20221215115258_MAterialState.Designer.cs
+++ b/Migrations/20221215115258_MAterialState.Designer.cs
@@ -4,6 +4,7 @@ using CarManufactoring.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CarManufactoring.Migrations
 {
     [DbContext(typeof(CarManufactoringContext))]
-    partial class CarManufactoringContextModelSnapshot : ModelSnapshot
+    [Migration("20221215115258_MAterialState")]
+    partial class MAterialState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20221215115258_MAterialState.cs
+++ b/Migrations/20221215115258_MAterialState.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CarManufactoring.Migrations
+{
+    public partial class MAterialState : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "State",
+                table: "Material");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Material",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(200)",
+                oldMaxLength: 200);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "EffectiveStartDate",
+                table: "CollaboratorShifts",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "EffectiveEndDate",
+                table: "CollaboratorShifts",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Material",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "State",
+                table: "Material",
+                type: "nvarchar(15)",
+                maxLength: 15,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "EffectiveStartDate",
+                table: "CollaboratorShifts",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "EffectiveEndDate",
+                table: "CollaboratorShifts",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
Quando se altera atributos/campos no modelo/base de dados é necessário fazer migration 